### PR TITLE
FIX: playwright-tests 수정

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -32,13 +32,13 @@ jobs:
       env:
         FG_ID: ${{ secrets.FG_ID }}
         FG_PW: ${{ secrets.FG_PW }}
-      run: pytest --reporter=html --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
+      run: pytest --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
 
     # 실패 시 원인 분석을 위한 레코드
-    - name: Upload Playwright Report
-      if: failure() # 테스트가 실패했을 때만 실행
+    - name: Upload Test Results
+      if: failure() 
       uses: actions/upload-artifact@v4
       with:
-        name: playwright-report
-        path: playwright-report/ 
+        name: test-results
+        path: test-results/ 
         retention-days: 30

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -23,9 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt  # 의존성 파일 설치
-        # 만약 playwright가 requirements.txt에 없다면 아래 줄 주석 해제
-        # pip install playwright pytest 
+        pip install -r requirements.txt  
 
     - name: Install Playwright Browsers
       run: playwright install --with-deps chromium # 필요한 브라우저만 설치 (속도 최적화)

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         FG_ID: ${{ secrets.FG_ID }}
         FG_PW: ${{ secrets.FG_PW }}
-      run: pytest --returns 2 --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
+      run: pytest --reruns 2 --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
 
     # 실패 시 원인 분석을 위한 레코드
     - name: Upload Test Results

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      FG_ID: ${{ secrets.FG_ID }}
-      FG_PW: ${{ secrets.FG_PW }}
+      FG_ID: ${{ secrets.LOGIN_EMAIL }}
+      FG_PW: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3 # Docker Buildx 설정
+        env: 
+          SHM_SIZE: 2gb
 
       - name: Build services
         run: docker compose build # Docker Compose를 사용하여 서비스 빌드

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      FG_ID: ${{ secrets.LOGIN_EMAIL }}
-      FG_PW: ${{ secrets.LOGIN_PASSWORD }}
+      FG_ID: ${{ secrets.FG_ID }}
+      FG_PW: ${{ secrets.FG_PW }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         FG_ID: ${{ secrets.FG_ID }}
         FG_PW: ${{ secrets.FG_PW }}
-      run: pytest --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
+      run: pytest --returns 2 --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
 
     # 실패 시 원인 분석을 위한 레코드
     - name: Upload Test Results

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install pytest-rerunfailures
         pip install -r requirements.txt  
 
     - name: Install Playwright Browsers

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     env:
       FG_ID: ${{ secrets.FG_ID }}
-      FG_PW: ${{ secrets.FG_PW }}
+      FG_PW: ${{ secrets.FG_PW }} 
 
     steps:
       - name: Checkout code

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         FG_ID: ${{ secrets.FG_ID }}
         FG_PW: ${{ secrets.FG_PW }}
-      run: pytest 
+      run: pytest --reporter=html --tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure
 
     # 실패 시 원인 분석을 위한 레코드
     - name: Upload Playwright Report

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -7,26 +7,40 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
-    env:
-      FG_ID: ${{ secrets.FG_ID }}
-      FG_PW: ${{ secrets.FG_PW }} 
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4 # github 가상 서버에 코드 로드
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 # Docker Buildx 설정
-        env: 
-          SHM_SIZE: 2gb
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip' # pip 패키지 캐싱 (속도 향상)
 
-      - name: Build services
-        run: docker compose build # Docker Compose를 사용하여 서비스 빌드
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt  # 의존성 파일 설치
+        # 만약 playwright가 requirements.txt에 없다면 아래 줄 주석 해제
+        # pip install playwright pytest 
 
-      - name: Run tests
-        run: docker compose up --abort-on-container-exit # 테스트 실행 및 컨테이너 종료 시 중단
+    - name: Install Playwright Browsers
+      run: playwright install --with-deps chromium # 필요한 브라우저만 설치 (속도 최적화)
 
+    - name: Run Playwright tests
+      env:
+        FG_ID: ${{ secrets.FG_ID }}
+        FG_PW: ${{ secrets.FG_PW }}
+      run: pytest 
 
-        
+    # 실패 시 원인 분석을 위한 레코드
+    - name: Upload Playwright Report
+      if: failure() # 테스트가 실패했을 때만 실행
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/ 
+        retention-days: 30

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -9,6 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      FG_ID: ${{ secrets.FG_ID }}
+      FG_PW: ${{ secrets.FG_PW }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4 # github 가상 서버에 코드 로드
@@ -21,5 +25,6 @@ jobs:
 
       - name: Run tests
         run: docker compose up --abort-on-container-exit # 테스트 실행 및 컨테이너 종료 시 중단
+
 
         

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ services:
     image: mytest:latest
     container_name: playwright-tests
     working_dir: /app
+    shm_size: '2gb'
     volumes:
       - .:/app
+      - /dev/shm:/dev/shm # 호스트의 shm 사용
     command: ["pytest", "-s", "-q"]
     environment:
       - FG_ID=${FG_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,6 @@ services:
     volumes:
       - .:/app
     command: ["pytest", "-s", "-q"]
+    environment:
+      - LOGIN_EMAIL=${FG_ID}
+      - LOGIN_PASSWORD=${FG_PW}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,5 @@ services:
       - .:/app
     command: ["pytest", "-s", "-q"]
     environment:
-      - LOGIN_EMAIL=${FG_ID}
-      - LOGIN_PASSWORD=${FG_PW}
+      - FG_ID=${FG_ID}
+      - FG_PW=${FG_PW}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   playwright:
     build: .

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -12,7 +12,7 @@ class LoginPage:
 
     def login(self, username: str, password: str):
         self.page.wait_for_load_state("domcontentloaded")
-        self.page.wait_for_load_state("networkidel") # 네트워크 안정화 대기
+        self.page.wait_for_load_state("networkidle") # 네트워크 안정화 대기
 
         # 이메일 입력
         self.email.click()

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -12,29 +12,29 @@ class LoginPage:
 
     def login(self, username: str, password: str):
         self.page.wait_for_load_state("domcontentloaded")
+        self.page.wait_for_load_state("networkidel") # 네트워크 안정화 대기
 
         # 이메일 입력
         self.email.click()
-        self.page.keyboard.type(username, delay=80)  # 실제 키보드 입력 느낌
-        self.page.wait_for_timeout(200)
-        self.email.blur()
-        self.page.wait_for_timeout(200)
+        self.email.focus() # focus 명시적 호출
+        self.page.keyboard.type(username, delay=80)
+
+        self.email.evaluate("el => el.dispatchEvent(new Event('input', { bubbles: true}))")
+        self.email.evaluate("el => el.dispatchEvent(new Event('change', { bubbles: true}))")
+        self.page.wait_for_timeout(300)
 
         # 비밀번호 입력
         self.password.click()
+        self.password.focus()
         self.page.keyboard.type(password, delay=80)
-        self.page.wait_for_timeout(200)
-        self.password.blur()
-        self.page.wait_for_timeout(200)
+
+        self.email.evaluate("el => el.dispatchEvent(new Event('input', { bubbles : true }))")
+        self.email.evaluate("el => el.dispatchEvent(new Event('change', { bubbles : true }))")
+        self.page.wait_for_timeout(300)
+        
 
         # 버튼 활성화 대기
-        for _ in range(40):
-            if self.submit_btn.is_enabled():
-                break
-            self.page.wait_for_timeout(300)
-        else:
-            raise Exception("로그인 버튼이 활성화되지 않았습니다.")
-
+        self.submit_btn.wait_for(state="enabled", timeout=10000)
         self.submit_btn.click()
 
         # 로그인 성공 요소 확인

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -8,34 +8,35 @@ class LoginPage:
         self.email = page.locator("#email-inp")
         self.password = page.locator("#pwd_inp")
         self.submit_btn = page.locator("button#btn-signin")
-        self.user_avatar = page.locator("a.user-avatar")  # 로그인 후 뜨는 요소
+        self.user_avatar = page.locator("a.user-avatar")
 
     def login(self, username: str, password: str):
+        # 1. 네트워크 아이들 제거 -> 대신 요소가 'Editable' 상태인지 확인
+        # domcontentloaded는 유지하되, 핵심은 입력창이 준비되었느냐입니다.
         self.page.wait_for_load_state("domcontentloaded")
-        self.page.wait_for_load_state("networkidle") # 네트워크 안정화 대기
-
-        # 이메일 입력
-        self.email.click()
-        self.email.focus() # focus 명시적 호출
-        self.page.keyboard.type(username, delay=80)
-
-        self.email.evaluate("el => el.dispatchEvent(new Event('input', { bubbles: true}))")
-        self.email.evaluate("el => el.dispatchEvent(new Event('change', { bubbles: true}))")
-        self.page.wait_for_timeout(300)
-
-        # 비밀번호 입력
-        self.password.click()
-        self.password.focus()
-        self.page.keyboard.type(password, delay=80)
-
-        self.password.evaluate("el => el.dispatchEvent(new Event('input', { bubbles : true }))")
-        self.password.evaluate("el => el.dispatchEvent(new Event('change', { bubbles : true }))")
-        self.page.wait_for_timeout(300)
         
+        # [핵심 1] 이메일 입력
+        # page.keyboard 대신 locator.press_sequentially 사용 (요소에 직접 입력)
+        # delay를 100ms로 늘려 CI의 낮은 CPU 성능을 배려
+        self.email.click() # 혹시 모를 포커스 트리거를 위해 클릭은 유지
+        self.email.press_sequentially(username, delay=100)
+        
+        # [핵심 2] 'Tab' 키로 자연스러운 Blur 유도 (가장 확실한 유효성 검사 트리거)
+        # 강제 dispatchEvent보다 Tab키가 프론트엔드 프레임워크 입장에서 더 자연스럽습니다.
+        self.email.press("Tab") 
+        
+        # CI 속도 고려하여 아주 짧은 안정화 대기 (필수는 아니나 안전장치)
+        self.page.wait_for_timeout(500)
 
-        # 버튼 활성화 대기
-        expect(self.submit_btn).to_be_enabled(timeout=10000)
+        # [핵심 3] 비밀번호 입력
+        self.password.click()
+        self.password.press_sequentially(password, delay=100)
+        self.password.press("Tab") # 입력 후 탭을 눌러 포커스 뺌 -> 유효성 검사 발동
+        
+        # [핵심 4] 버튼 활성화 'Assertions' (Retry 로직 내장)
+        # 단순히 기다리는게 아니라, enabled 될 때까지 Playwright가 계속 찔러봅니다.
+        expect(self.submit_btn).to_be_enabled(timeout=15000) # CI 고려 15초로 넉넉하게
         self.submit_btn.click()
 
-        # 로그인 성공 요소 확인
-        expect(self.user_avatar).to_be_visible(timeout=5000)
+        # 로그인 성공 확인
+        expect(self.user_avatar).to_be_visible(timeout=10000)

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -2,42 +2,32 @@
 import time
 from playwright.sync_api import Page, expect
 
-class LoginPage:
-    def __init__(self, page: Page):
-        self.page = page
-        self.email = page.locator("#email-inp")
-        self.password = page.locator("#pwd_inp")
-        self.submit_btn = page.locator("button#btn-signin")
-        self.user_avatar = page.locator("a.user-avatar")  # 로그인 후 뜨는 요소
+def login(self, username: str, password: str):
+    self.page.wait_for_load_state("domcontentloaded")
 
-    def login(self, username: str, password: str):
+    # 이메일 입력
+    self.email.click()
+    self.page.keyboard.type(username, delay=80)  # 실제 키보드 입력으로 구동
+    self.page.wait_for_timeout(200)
+    self.email.blur()
+    self.page.wait_for_timeout(200)
 
-        try:
-            cookie_button = self.page.locator('#onetrust-accept-btn-handler')
-            if cookie_button.is_visible():
-                cookie_button.click()
-        except:
-            pass
-        
-        self.page.wait_for_timeout(500)
+    # 비밀번호 입력
+    self.password.click()
+    self.page.keyboard.type(password, delay=80)
+    self.page.wait_for_timeout(200)
+    self.password.blur()
+    self.page.wait_for_timeout(200)
 
-        self.email.click()
-        self.email.type(username, delay=50)
-        self.page.wait_for_timeout(200)
+    # 버튼 활성화 대기
+    for _ in range(40):
+        if self.submit_btn.is_enabled():
+            break
+        self.page.wait_for_timeout(300)
+    else:
+        raise Exception("로그인 버튼이 활성화되지 않았습니다.")
 
-        self.password.click()
-        self.password.type(password, delay=50)
-        self.page.wait_for_timeout(200)
+    self.submit_btn.click()
 
-        # 버튼 비활성 예외 처리
-        for _ in range(40):
-            if self.submit_btn.is_enabled():
-                break
-            time.sleep(0.5)
-        else:
-            raise Exception("로그인 버튼이 활성화되지 않았습니다.")
-
-        self.submit_btn.click()
-
-        # 로그인 성공 여부 확인
-        expect(self.user_avatar).to_be_visible(timeout=5000)
+    # 로그인 성공 요소 확인
+    expect(self.user_avatar).to_be_visible(timeout=5000)

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -2,32 +2,40 @@
 import time
 from playwright.sync_api import Page, expect
 
-def login(self, username: str, password: str):
-    self.page.wait_for_load_state("domcontentloaded")
+class LoginPage:
+    def __init__(self, page: Page):
+        self.page = page
+        self.email = page.locator("#email-inp")
+        self.password = page.locator("#pwd_inp")
+        self.submit_btn = page.locator("button#btn-signin")
+        self.user_avatar = page.locator("a.user-avatar")  # 로그인 후 뜨는 요소
 
-    # 이메일 입력
-    self.email.click()
-    self.page.keyboard.type(username, delay=80)  # 실제 키보드 입력으로 구동
-    self.page.wait_for_timeout(200)
-    self.email.blur()
-    self.page.wait_for_timeout(200)
+    def login(self, username: str, password: str):
+        self.page.wait_for_load_state("domcontentloaded")
 
-    # 비밀번호 입력
-    self.password.click()
-    self.page.keyboard.type(password, delay=80)
-    self.page.wait_for_timeout(200)
-    self.password.blur()
-    self.page.wait_for_timeout(200)
+        # 이메일 입력
+        self.email.click()
+        self.page.keyboard.type(username, delay=80)  # 실제 키보드 입력 느낌
+        self.page.wait_for_timeout(200)
+        self.email.blur()
+        self.page.wait_for_timeout(200)
 
-    # 버튼 활성화 대기
-    for _ in range(40):
-        if self.submit_btn.is_enabled():
-            break
-        self.page.wait_for_timeout(300)
-    else:
-        raise Exception("로그인 버튼이 활성화되지 않았습니다.")
+        # 비밀번호 입력
+        self.password.click()
+        self.page.keyboard.type(password, delay=80)
+        self.page.wait_for_timeout(200)
+        self.password.blur()
+        self.page.wait_for_timeout(200)
 
-    self.submit_btn.click()
+        # 버튼 활성화 대기
+        for _ in range(40):
+            if self.submit_btn.is_enabled():
+                break
+            self.page.wait_for_timeout(300)
+        else:
+            raise Exception("로그인 버튼이 활성화되지 않았습니다.")
 
-    # 로그인 성공 요소 확인
-    expect(self.user_avatar).to_be_visible(timeout=5000)
+        self.submit_btn.click()
+
+        # 로그인 성공 요소 확인
+        expect(self.user_avatar).to_be_visible(timeout=5000)

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -28,8 +28,8 @@ class LoginPage:
         self.password.focus()
         self.page.keyboard.type(password, delay=80)
 
-        self.email.evaluate("el => el.dispatchEvent(new Event('input', { bubbles : true }))")
-        self.email.evaluate("el => el.dispatchEvent(new Event('change', { bubbles : true }))")
+        self.password.evaluate("el => el.dispatchEvent(new Event('input', { bubbles : true }))")
+        self.password.evaluate("el => el.dispatchEvent(new Event('change', { bubbles : true }))")
         self.page.wait_for_timeout(300)
         
 

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -11,13 +11,23 @@ class LoginPage:
         self.user_avatar = page.locator("a.user-avatar")  # 로그인 후 뜨는 요소
 
     def login(self, username: str, password: str):
+
+        try:
+            cookie_button = self.page.locator('#onetrust-accept-btn-handler')
+            if cookie_button.is_visible():
+                cookie_button.click()
+        except:
+            pass
+        
+        self.page.wait_for_timeout(500)
+
         self.email.click()
-        self.email.fill("")  # 입력 필드 초기화
-        self.email.type(username, delay=50)  
+        self.email.type(username, delay=50)
+        self.page.wait_for_timeout(200)
 
         self.password.click()
-        self.password.fill("")
         self.password.type(password, delay=50)
+        self.page.wait_for_timeout(200)
 
         # 버튼 비활성 예외 처리
         for _ in range(40):
@@ -29,5 +39,5 @@ class LoginPage:
 
         self.submit_btn.click()
 
-        expect(self.user_avatar).to_be_visible(timeout=5000)   #로그인 성공 대기
-
+        # 로그인 성공 여부 확인
+        expect(self.user_avatar).to_be_visible(timeout=5000)

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -32,7 +32,14 @@ class LoginPage:
         # 버튼 활성화 'Assertions' (Retry 로직 내장)
         # enabled 될 때까지 Playwright가 계속 찔러봅니다.
         expect(self.submit_btn).to_be_enabled(timeout=30000) # CI 고려 15초로 넉넉하게
-        self.submit_btn.click()
+
+        print("로그인 버튼 클릭 시도...")
+        try:
+            with self.page.expect_navigation(timeout=30000):
+                self.submit_btn.click(force=True)
+        except Exception as e:
+            print(f"페이지 이동 감지 실패: {e}")
 
         # 로그인 성공 확인
+        print("로그인 성공 여부 확인 중...")
         expect(self.user_avatar).to_be_visible(timeout=30000)

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -10,31 +10,26 @@ class LoginPage:
         self.submit_btn = page.locator("button#btn-signin")
         self.user_avatar = page.locator("a.user-avatar")
 
-    def login(self, username: str, password: str):
-        # 1. 네트워크 아이들 제거 -> 대신 요소가 'Editable' 상태인지 확인
-        # domcontentloaded는 유지하되, 핵심은 입력창이 준비되었느냐입니다.
-        self.page.wait_for_load_state("domcontentloaded")
+    def login(self, username: str, password: str):        
+        self.page.wait_for_load_state("domcontentloaded") # 입력창 준비 완료 확인
         
-        # [핵심 1] 이메일 입력
-        # page.keyboard 대신 locator.press_sequentially 사용 (요소에 직접 입력)
-        # delay를 100ms로 늘려 CI의 낮은 CPU 성능을 배려
-        self.email.click() # 혹시 모를 포커스 트리거를 위해 클릭은 유지
+        # 이메일 입력
+        # locator.press_sequentially 사용 (요소에 직접 입력)
+        # delay를 100ms로 늘려 CI의 낮은 CPU 성능을 고려
+        self.email.click() # 클릭 유지
         self.email.press_sequentially(username, delay=100)
         
-        # [핵심 2] 'Tab' 키로 자연스러운 Blur 유도 (가장 확실한 유효성 검사 트리거)
-        # 강제 dispatchEvent보다 Tab키가 프론트엔드 프레임워크 입장에서 더 자연스럽습니다.
+        # 'Tab' 키로 자연스러운 Blur 유도
         self.email.press("Tab") 
-        
-        # CI 속도 고려하여 아주 짧은 안정화 대기 (필수는 아니나 안전장치)
         self.page.wait_for_timeout(500)
 
-        # [핵심 3] 비밀번호 입력
+        # 비밀번호 입력
         self.password.click()
         self.password.press_sequentially(password, delay=100)
-        self.password.press("Tab") # 입력 후 탭을 눌러 포커스 뺌 -> 유효성 검사 발동
+        self.password.press("Tab") # 탭 눌러서 포커스 해제
         
-        # [핵심 4] 버튼 활성화 'Assertions' (Retry 로직 내장)
-        # 단순히 기다리는게 아니라, enabled 될 때까지 Playwright가 계속 찔러봅니다.
+        # 버튼 활성화 'Assertions' (Retry 로직 내장)
+        # enabled 될 때까지 Playwright가 계속 찔러봅니다.
         expect(self.submit_btn).to_be_enabled(timeout=15000) # CI 고려 15초로 넉넉하게
         self.submit_btn.click()
 

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -1,5 +1,4 @@
 # pages/page_login.py
-import time
 from playwright.sync_api import Page, expect
 
 class LoginPage:
@@ -8,34 +7,51 @@ class LoginPage:
         self.email = page.locator("#email-inp")
         self.password = page.locator("#pwd_inp")
         self.submit_btn = page.locator("button#btn-signin")
-        self.user_avatar = page.locator("a.user-avatar")  # 로그인 후 뜨는 요소
+        self.user_avatar = page.locator("a.user-avatar")
 
     def login(self, username: str, password: str):
+        # 페이지 완전 로드 대기
         self.page.wait_for_load_state("domcontentloaded")
-        self.page.wait_for_load_state("networkidle") # 네트워크 안정화 대기
+        self.page.wait_for_load_state("networkidle")  # 네트워크까지 완전 대기
+        self.page.wait_for_timeout(1500)  # 추가 여유
+        
+        # 입력 필드가 실제로 보일 때까지 대기
+        self.email.wait_for(state="visible", timeout=5000)
+        self.password.wait_for(state="visible", timeout=5000)
 
         # 이메일 입력
         self.email.click()
-        self.email.focus() # focus 명시적 호출
-        self.page.keyboard.type(username, delay=80)
-
-        self.email.evaluate("el => el.dispatchEvent(new Event('input', { bubbles: true}))")
-        self.email.evaluate("el => el.dispatchEvent(new Event('change', { bubbles: true}))")
-        self.page.wait_for_timeout(300)
+        self.email.type(username, delay=50)
+        self.page.wait_for_timeout(500)
 
         # 비밀번호 입력
         self.password.click()
-        self.password.focus()
-        self.page.keyboard.type(password, delay=80)
+        self.password.type(password, delay=50)
+        self.page.wait_for_timeout(500)
 
-        self.password.evaluate("el => el.dispatchEvent(new Event('input', { bubbles : true }))")
-        self.password.evaluate("el => el.dispatchEvent(new Event('change', { bubbles : true }))")
-        self.page.wait_for_timeout(300)
+        # 버튼 활성화 폴링 (더 긴 timeout)
+        max_attempts = 50
+        for i in range(max_attempts):
+            if not self.submit_btn.is_disabled():
+                print(f"✅ 버튼 활성화됨 (시도 {i+1}/{max_attempts})")
+                break
+            self.page.wait_for_timeout(300)
+        else:
+            # 디버깅용 스크린샷
+            self.page.screenshot(path="button_not_enabled.png")
+            
+            # 버튼 상태 확인
+            is_disabled = self.submit_btn.get_attribute("disabled")
+            print(f"❌ 버튼 disabled 속성: {is_disabled}")
+            
+            raise TimeoutError("로그인 버튼이 활성화되지 않았습니다.")
+
+        # 로그인 버튼 클릭
+        with self.page.expect_navigation(wait_until="domcontentloaded", timeout=60000):
+            self.submit_btn.click()
+
+        self.page.wait_for_timeout(1000)
         
-
-        # 버튼 활성화 대기
-        expect(self.submit_btn).to_be_enabled(timeout=10000)
-        self.submit_btn.click()
-
-        # 로그인 성공 요소 확인
+        # 로그인 성공 확인
         expect(self.user_avatar).to_be_visible(timeout=5000)
+        print("✅ 로그인 성공")

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -34,7 +34,7 @@ class LoginPage:
         
 
         # 버튼 활성화 대기
-        self.submit_btn.wait_for(state="enabled", timeout=10000)
+        expect(self.submit_btn).to_be_enabled(timeout=10000)
         self.submit_btn.click()
 
         # 로그인 성공 요소 확인

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -20,7 +20,7 @@ class LoginPage:
         self.password.type(password, delay=50)
 
         # 버튼 비활성 예외 처리
-        for _ in range(20):
+        for _ in range(40):
             if self.submit_btn.is_enabled():
                 break
             time.sleep(0.5)

--- a/pages/page_login.py
+++ b/pages/page_login.py
@@ -17,7 +17,7 @@ class LoginPage:
         # locator.press_sequentially 사용 (요소에 직접 입력)
         # delay를 100ms로 늘려 CI의 낮은 CPU 성능을 고려
         self.email.click() # 클릭 유지
-        self.email.press_sequentially(username, delay=100)
+        self.email.press_sequentially(username, delay=200)
         
         # 'Tab' 키로 자연스러운 Blur 유도
         self.email.press("Tab") 
@@ -25,13 +25,14 @@ class LoginPage:
 
         # 비밀번호 입력
         self.password.click()
-        self.password.press_sequentially(password, delay=100)
+        self.password.press_sequentially(password, delay=200)
         self.password.press("Tab") # 탭 눌러서 포커스 해제
+        self.page.wait_for_timeout(1000)
         
         # 버튼 활성화 'Assertions' (Retry 로직 내장)
         # enabled 될 때까지 Playwright가 계속 찔러봅니다.
-        expect(self.submit_btn).to_be_enabled(timeout=15000) # CI 고려 15초로 넉넉하게
+        expect(self.submit_btn).to_be_enabled(timeout=30000) # CI 고려 15초로 넉넉하게
         self.submit_btn.click()
 
         # 로그인 성공 확인
-        expect(self.user_avatar).to_be_visible(timeout=10000)
+        expect(self.user_avatar).to_be_visible(timeout=30000)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+addopts = --base-url https://... --browser chromium --slowmo 500

--- a/test.py
+++ b/test.py
@@ -1,9 +1,0 @@
-from playwright.sync_api import sync_playwright
-
-def test_basic():
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
-        page = browser.new_page()
-        page.goto("https://google.com")
-        print(page.title())
-        browser.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,10 @@ def playwright_instance():
 
 @pytest.fixture(scope="session")
 def browser(playwright_instance):
-    browser = playwright_instance.chromium.launch(headless=IS_DOCKER)
+    browser = playwright_instance.chromium.launch(
+        headless=IS_DOCKER,
+        args=["--disable-blink-features=AutomationControlled", "--disable-gpu"]
+        )
     yield browser
     browser.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,8 @@ def browser(playwright_instance):
 
 @pytest.fixture(scope="function")
 def page(browser):
-    # 브라우저 컨텍스트 생성 (뷰포트 크기 등을 여기서 설정 가능)
     context = browser.new_context(
-        viewport={"width": 1920, "height": 1080} # CI 환경에서 화면 크기 고정 (권장)
+        viewport={"width": 1920, "height": 1080} # CI 환경에서 화면 크기 고정
     )
     page = context.new_page()
     yield page

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ EMAIL = os.getenv("FG_ID")
 PASSWORD = os.getenv("FG_PW")
 
 # 2. 실행 모드 감지 로직 (핵심 수정 부분)
-# GitHub Actions는 자동으로 'CI=true'를 설정해줍니다.
+# GitHub Actions는 자동으로 'CI=true'를 설정
 IS_CI = os.getenv("CI", "false") == "true"
 IS_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false") == "true"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,15 @@ def playwright_instance():
 def browser(playwright_instance):
     browser = playwright_instance.chromium.launch(
         headless=IS_DOCKER,
-        args=["--disable-blink-features=AutomationControlled", "--disable-gpu"]
+        args=["--disable-blink-features=AutomationControlled", "--disable-gpu",
+              '--disable-dev-shm-usage',      # ✅ /dev/shm 사용 안 함
+                '--no-sandbox',                  # ✅ sandbox 비활성화
+                '--disable-setuid-sandbox',      # ✅ setuid sandbox 비활성화
+                '--disable-gpu',                 # ✅ GPU 비활성화
+                '--disable-web-security',        # ✅ CORS 등 보안 정책 완화
+                '--disable-features=IsolateOrigins,site-per-process',  # ✅ 프로세스 격리 비활성화
+        ]
+                
         )
     yield browser
     browser.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ import os
 
 load_dotenv() # env 파일 로드
 
-EMAIL = os.getenv("LOGIN_EMAIL")
-PASSWORD = os.getenv("LOGIN_PASSWORD")
+EMAIL = os.getenv("FG_ID")
+PASSWORD = os.getenv("FG_PW")
 IS_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false") == "true"
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,25 @@
 import pytest
+import os
+from dotenv import load_dotenv
+from playwright.sync_api import sync_playwright
+
+# Page Objects import
 from pages.page_main import MainPage
 from pages.page_login import LoginPage
-from playwright.sync_api import sync_playwright
-from dotenv import load_dotenv
-import os
 
-load_dotenv() # env 파일 로드
+load_dotenv() # .env 파일 로드
 
+# 1. 환경 변수 설정
 EMAIL = os.getenv("FG_ID")
 PASSWORD = os.getenv("FG_PW")
+
+# 2. 실행 모드 감지 로직 (핵심 수정 부분)
+# GitHub Actions는 자동으로 'CI=true'를 설정해줍니다.
+IS_CI = os.getenv("CI", "false") == "true"
 IS_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false") == "true"
+
+# CI 환경이거나 Docker 환경이면 Headless로 실행 (창을 띄우지 않음)
+HEADLESS_MODE = IS_CI or IS_DOCKER
 
 @pytest.fixture(scope="session")
 def credentials():
@@ -25,24 +35,29 @@ def playwright_instance():
 
 @pytest.fixture(scope="session")
 def browser(playwright_instance):
+    print(f"\n[Browser Setup] Headless Mode: {HEADLESS_MODE}")
+    
     browser = playwright_instance.chromium.launch(
-        headless=IS_DOCKER,
-        args=["--disable-blink-features=AutomationControlled", "--disable-gpu",
-              '--disable-dev-shm-usage',      # ✅ /dev/shm 사용 안 함
-                '--no-sandbox',                  # ✅ sandbox 비활성화
-                '--disable-setuid-sandbox',      # ✅ setuid sandbox 비활성화
-                '--disable-gpu',                 # ✅ GPU 비활성화
-                '--disable-web-security',        # ✅ CORS 등 보안 정책 완화
-                '--disable-features=IsolateOrigins,site-per-process',  # ✅ 프로세스 격리 비활성화
+        headless=HEADLESS_MODE,  # ✅ 환경에 따라 True/False 자동 적용
+        args=[
+            "--disable-blink-features=AutomationControlled",
+            "--disable-gpu",
+            "--disable-dev-shm-usage",
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-web-security",
+            "--disable-features=IsolateOrigins,site-per-process",
         ]
-                
-        )
+    )
     yield browser
     browser.close()
 
 @pytest.fixture(scope="function")
 def page(browser):
-    context = browser.new_context()
+    # 브라우저 컨텍스트 생성 (뷰포트 크기 등을 여기서 설정 가능)
+    context = browser.new_context(
+        viewport={"width": 1920, "height": 1080} # CI 환경에서 화면 크기 고정 (권장)
+    )
     page = context.new_page()
     yield page
     context.close()
@@ -54,4 +69,3 @@ def main_page(page):
 @pytest.fixture
 def login_page(page):
     return LoginPage(page)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,18 @@ def playwright_instance():
 @pytest.fixture(scope="session")
 def browser(playwright_instance):
     print(f"\n[Browser Setup] Headless Mode: {HEADLESS_MODE}")
+    # --- 디버깅용 로그 추가 ---
+    print("\n" + "="*30)
+    print(f"Checking Env Vars in CI:")
     
+    id_val = os.getenv("FG_ID")
+    pw_val = os.getenv("FG_PW")
+
+    # 값이 있는지 없는지 O/X로 출력 (보안상 실제 값 출력 X)
+    print(f" -> FG_ID Exists? : {'YES' if id_val else 'NO (Empty!)'}")
+    print(f" -> FG_PW Exists? : {'YES' if pw_val else 'NO (Empty!)'}")
+    print("="*30 + "\n")
+    # -----------------------
     browser = playwright_instance.chromium.launch(
         headless=HEADLESS_MODE,  # ✅ 환경에 따라 True/False 자동 적용
         args=[

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,3 +1,5 @@
+import os
+
 def test_login(main_page, login_page, credentials):
 
     # main 으로 이동
@@ -5,6 +7,9 @@ def test_login(main_page, login_page, credentials):
 
     # 로그인 페이지로 이동
     main_page.click_login()
+
+    print("CI FG_ID", os.getenv("FG_ID"))
+    print("CI FG_PW", os.getenv("FG_PW"))
 
     # 로그인 시도
     login_page.login(credentials["email"], credentials["password"])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now installs browsers, runs end-to-end tests with credentials from environment, uploads reports on failure, and has an extended timeout; compose adds shared-memory and passes credentials at startup.

* **Tests**
  * Removed a simple smoke test; test runs now print credential env values, use a stable viewport and hardened browser launch options, and include retries/tracing for flaky failures.

* **Bug Fixes**
  * Improved login automation with sequential typing, stabilization waits, explicit enabled-state checks, and clearer success verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->